### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WGif is a command line tool for creating animated GIFs from YouTube videos.
 
 — [Kevin Liddle](https://github.com/KevinLiddle), Software Craftsman
 
-##TL;DR
+## TL;DR
 ```
 Usage: wgif [YouTube URL] [output file] [options]
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
